### PR TITLE
Read process.env.HOMEPATH in Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ function main(argv) {
     }
     var AWS = require('aws-sdk');
     try {
-      var iniFile = fs.readFileSync(path.join(process.env.HOME, '.aws', 'config'), 'utf8');
+      var iniFile = fs.readFileSync(path.join(process.env.HOME || process.env.HOMEPATH, '.aws', 'config'), 'utf8');
       var iniData = ini.decode(iniFile);
       var section = iniData[process.env.AWS_PROFILE ? 'profile ' + process.env.AWS_PROFILE : 'default'];
       if (section.region) {


### PR DESCRIPTION
I had tried to create CloudWatch Logs tail tool.
But I found your tool.

Could you support Windows environment?

http://shapeshed.com/writing-cross-platform-node/

> On *nix your home directory is process.env.HOME but in Windows the home directory is proces.env.HOMEPATH.
