### PR TITLE
Support proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,6 +173,12 @@ function main(argv) {
       // Ini file not found, ignore
       console.error(err);
     }
+    if (process.env.https_proxy) {
+      var proxy = require('proxy-agent');
+      AWS.config.update({
+          httpOptions: { agent: proxy(process.env.https_proxy) }
+      })
+    }
     var logs = new AWS.CloudWatchLogs();
     Promise.promisifyAll(logs);
     if (!arg.options.list && !arg.argv.length) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "aws-sdk": "^2.2.21",
     "bluebird": "^3.0.6",
     "ini": "^1.3.4",
-    "node-getopt": "^0.2.3"
+    "node-getopt": "^0.2.3",
+    "proxy-agent": "^2.0.0"
   }
 }


### PR DESCRIPTION
AWS SDK requires explicit settings for proxy.
http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Configuring_a_Proxy

I tried proxy-agent.
If there is no problem, could you merge this?
