### PR TITLE
Fix user's home path problem for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ function main(argv) {
       AWS.config.update({ region: process.env.AWS_REGION });
     } else {
       try {
-        var iniFile = fs.readFileSync(path.join(process.env.HOME || process.env.HOMEPATH, '.aws', 'config'), 'utf8');
+        var iniFile = fs.readFileSync(path.join(process.env.HOME || os.homedir(), '.aws', 'config'), 'utf8');
         var iniData = ini.decode(iniFile);
         var section = iniData[process.env.AWS_PROFILE ? 'profile ' + process.env.AWS_PROFILE : 'default'];
         if (section.region) {


### PR DESCRIPTION
cwtail throws error if called from drives other that c: under Windows while retrieving AWS user profile. Changing `process.env.HOMEPATH` to `os.homedir()` should fix this problem.